### PR TITLE
feat: fill empty intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ client = Druid::Client.new
 # With custom tuning_granularity:
 client = Druid::Client.new(tuning_granularity: :hour)
 ```
-*Note:* There are many configuration options, please take a look at 
+*Note:* There are many configuration options, please take a look at
 `Druid::Configuration` for more details.
 
 ### Administrative Tasks
@@ -98,13 +98,37 @@ start_time = Time.now.utc.advance(days: -30)
 client.query(
   queryType: 'timeseries',
   dataSource: 'foo',
-  granularity: 'minute',
-  intervals: [start_time.iso8601 + '/' + Time.now.utc.iso8601],
+  granularity: 'day',
+  intervals: start_time.iso8601 + '/' + Time.now.utc.iso8601,
   aggregations: [{ type: 'longSum', name: 'baz', fieldName: 'baz' }]
 )
 ```
 *Note:* The `query` method just POSTs the query to Druid; for information on
-querying Druid: http://druid.io/docs/latest/querying/querying.html
+querying Druid: http://druid.io/docs/latest/querying/querying.html. This is
+intentionally simple to allow all current features and hopefully all future
+features of the Druid query language without updating the gem.
+
+Fill Empty Intervals:
+
+Currently, Druid will not fill empty intervals for which there are no points. To
+accommodate this need until it is handled more efficiently in Druid, use the
+experimental `fill_value` feature in your query. This ensure you get an result
+for every interval in intervals.
+
+This has only been tested with 'timeseries' and single-dimension 'groupBy'
+queries with simple granularities.
+```
+start_time = Time.now.utc.advance(days: -30)
+
+client.query(
+  queryType: 'timeseries',
+  dataSource: 'foo',
+  granularity: 'day',
+  intervals: start_time.iso8601 + '/' + Time.now.utc.iso8601,
+  aggregations: [{ type: 'longSum', name: 'baz', fieldName: 'baz' }],
+  fill_value: 0
+)
+```
 
 ## Testing
 

--- a/lib/druid/client.rb
+++ b/lib/druid/client.rb
@@ -1,8 +1,8 @@
 module Druid
   class Client
-    include Druid::Query::Core
-    include Druid::Query::Datasource
-    include Druid::Query::Task
+    include Druid::Queries::Core
+    include Druid::Queries::Datasource
+    include Druid::Queries::Task
 
     attr_reader :broker,
                 :config,

--- a/lib/druid/queries/core.rb
+++ b/lib/druid/queries/core.rb
@@ -1,0 +1,11 @@
+module Druid
+  module Queries
+    module Core
+      delegate :write_point, to: :writer
+
+      def query(opts)
+        Druid::Query.create(opts.merge(broker: broker))
+      end
+    end
+  end
+end

--- a/lib/druid/queries/datasource.rb
+++ b/lib/druid/queries/datasource.rb
@@ -1,5 +1,5 @@
 module Druid
-  module Query
+  module Queries
     module Datasource
       java_import org.apache.zookeeper.ZKUtil
 

--- a/lib/druid/queries/task.rb
+++ b/lib/druid/queries/task.rb
@@ -1,5 +1,5 @@
 module Druid
-  module Query
+  module Queries
     module Task
       delegate :shutdown_tasks, to: :overlord
     end

--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -1,0 +1,182 @@
+module Druid
+  class Query
+    attr_reader :aggregations,
+                :broker,
+                :dimensions,
+                :end_interval,
+                :fill_value,
+                :granularity,
+                :query_opts,
+                :query_type,
+                :range,
+                :result_key,
+                :start_interval
+
+    def initialize(opts)
+      @aggregations = opts[:aggregations].map{|agg| agg[:name]}
+      @broker = opts[:broker]
+      @dimensions = opts[:dimensions]
+      @fill_value = opts[:fill_value]
+      @granularity = opts[:granularity]
+      @range = parse_range(opts[:intervals])
+      @query_type = opts[:queryType]
+      @end_interval = calculate_end_interval
+      @start_interval = calculate_start_interval
+      @query_opts = opts_for_query(opts)
+    end
+
+    def execute
+      result = broker.query(query_opts)
+      fill_query_results(result)
+    end
+
+    private
+
+    # TODO: Can this be made smarter? Prefer to avoid case statements.
+    # Cases found here: http://druid.io/docs/latest/querying/granularities.html
+    def advance_interval(time)
+      case granularity
+      when 'second'
+        time.advance(seconds: 1)
+      when 'minute'
+        time.advance(minutes: 1)
+      when 'fifteen_minute'
+        time.advance(minutes: 15)
+      when 'thirty_minute'
+        time.advance(minutes: 30)
+      when 'hour'
+        time.advance(hours: 1)
+      when 'day'
+        time.advance(days: 1)
+      when 'week'
+        time.advance(weeks: 1)
+      when 'month'
+        time.advance(months: 1)
+      when 'quarter'
+        time.advance(months: 3)
+      when 'year'
+        time.advance(years: 1)
+      else
+        raise Druid::QueryError, 'Unsupported granularity'
+      end
+    end
+
+    def calculate_end_interval
+      iso8601_duration_end_interval(range)
+    end
+
+    def calculate_start_interval
+      time = iso8601_duration_start_interval(range)
+      start_of_interval(time)
+    end
+
+    def fill_empty_intervals(points, opts = {})
+      interval = start_interval
+      result = []
+
+      while interval <= end_interval do
+        # TODO:
+        # This will search the points every time, could be more performant if
+        # we track the 'current point' in the points and only compare the
+        # current point's timestamp
+        point = find_or_create_point(interval, points)
+        aggregations.each do |aggregation|
+          point[result_key][aggregation] = fill_value if point[result_key][aggregation].blank?
+          point[result_key].merge!(opts)
+        end
+        result << point
+        interval = advance_interval(interval)
+      end
+
+      result
+    end
+
+    # NOTE:
+    # This responsibility really lies in Druid, but until the feature works
+    # reliably in Druid, this is serves the purpose.
+    # https://github.com/druid-io/druid/issues/2106
+    def fill_query_results(query_result)
+      return query_result unless query_result.present? && fill_value.present?
+      parse_result_key(query_result.first)
+
+      #TODO: handle multi-dimensional group by
+      if group_by?
+        result = []
+        dimension_key = dimensions.first
+        groups = query_result.group_by{ |point| point[result_key][dimension_key] }
+        groups.each do |dimension_value, dimension_points|
+          result += fill_empty_intervals(dimension_points, { dimension_key => dimension_value })
+        end
+        result
+      else
+        fill_empty_intervals(query_result)
+      end
+    end
+
+    def find_or_create_point(interval, points)
+      point = points.find{ |point| point['timestamp'].to_s.to_time == interval.to_time }
+      point.present? ? point : { 'timestamp' => interval.iso8601(3), result_key => {} }
+    end
+
+    def group_by?
+      query_type == 'groupBy'
+    end
+
+    def iso8601_duration_start_interval(duration)
+      duration.split('/').first.to_time.utc
+    end
+
+    def iso8601_duration_end_interval(duration)
+      duration.split('/').last.to_time.utc
+    end
+
+    def opts_for_query(opts)
+      opts.except(:fill_value, :broker)
+    end
+
+    def parse_range(range)
+      range.is_a?(Array) ? range.first : range
+    end
+
+    def parse_result_key(point)
+      @result_key = point['event'].present? ? 'event' : 'result'
+    end
+
+    # TODO: Can this be made smarter? Prefer to avoid case statements.
+    # Cases found here: http://druid.io/docs/latest/querying/granularities.html
+    def start_of_interval(time)
+      case granularity
+      when 'second'
+        time.change(usec: 0)
+      when 'minute'
+        time.beginning_of_minute
+      when 'fifteen_minute'
+        first_fifteen = [45, 30, 15, 0].detect{ |m| m <= time.min }
+        time.change(min: first_fifteen)
+      when 'thirty_minute'
+        first_thirty = [30, 0].detect{ |m| m <= time.min }
+        time.change(min: first_thirty)
+      when 'hour'
+        time.beginning_of_hour
+      when 'day'
+        time.beginning_of_day
+      when 'week'
+        time.beginning_of_week
+      when 'month'
+        time.beginning_of_month
+      when 'quarter'
+        time.beginning_of_quarter
+      when 'year'
+        time.beginning_of_year
+      else
+        time
+      end
+    end
+
+    class << self
+      def create(opts)
+        new(opts).execute
+      end
+    end
+  end
+end

--- a/lib/druid/query/core.rb
+++ b/lib/druid/query/core.rb
@@ -1,8 +1,0 @@
-module Druid
-  module Query
-    module Core
-      delegate :query, to: :broker
-      delegate :write_point, to: :writer
-    end
-  end
-end

--- a/lib/jruby-druid.rb
+++ b/lib/jruby-druid.rb
@@ -7,15 +7,16 @@ require "json"
 require "druid/configuration"
 require "druid/connection"
 require "druid/errors"
+require "druid/query"
 require "druid/version"
 
 require "druid/node/broker"
 require "druid/node/coordinator"
 require "druid/node/overlord"
 
-require "druid/query/core"
-require "druid/query/datasource"
-require "druid/query/task"
+require "druid/queries/core"
+require "druid/queries/datasource"
+require "druid/queries/task"
 
 require "druid/writer/base"
 

--- a/spec/druid/query_spec.rb
+++ b/spec/druid/query_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+
+describe Druid::Query do
+  subject { Druid::Query.new(opts) }
+  let(:query_time) { Time.now.utc }
+
+  let(:opts) {
+    {
+      queryType: 'timeseries',
+      dataSource: 'widgets',
+      granularity: 'day',
+      intervals: range,
+      aggregations: [
+        { type: 'longSum', name: 'anvils', fieldName: 'anvils' },
+        { type: 'longSum', name: 'dynamite', fieldName: 'dynamite' }
+      ],
+      broker: broker,
+      fill_value: fill_value
+    }
+  }
+
+  let(:query_opts) {
+    {
+      queryType: 'timeseries',
+      dataSource: 'widgets',
+      granularity: 'day',
+      intervals: range,
+      aggregations: [
+        { type: 'longSum', name: 'anvils', fieldName: 'anvils' },
+        { type: 'longSum', name: 'dynamite', fieldName: 'dynamite' }
+      ]
+    }
+  }
+
+  let(:range) { query_time.advance(days: -2).iso8601 + '/' + query_time.iso8601 }
+
+  let(:broker) { double('broker') }
+  let(:fill_value) { 0 }
+
+  let(:query_result) { [ interval_1, interval_2 ] }
+  let(:formatted_results) { [ filled_0, filled_1, filled_2 ] }
+
+  let(:timestamp_0) { query_time.advance(days: -2).beginning_of_day.iso8601(3) }
+  let(:timestamp_1) { query_time.advance(days: -1).beginning_of_day.iso8601(3) }
+  let(:timestamp_2) { query_time.beginning_of_day.iso8601(3) }
+
+  let(:filled_0) { { 'timestamp' => timestamp_0, 'event' => filled_0_result } }
+  let(:filled_0_result) { { 'anvils' => fill_value, 'dynamite' => fill_value } }
+
+  let(:interval_1) { { 'timestamp' => timestamp_1, 'event' => interval_1_result } }
+  let(:interval_1_result) { { 'anvils' => 100 } }
+  let(:filled_1) { { 'timestamp' => timestamp_1, 'event' => filled_1_result } }
+  let(:filled_1_result) { { 'anvils' => 100, 'dynamite' => fill_value } }
+
+  let(:interval_2) { { 'timestamp' => timestamp_2, 'event' => interval_2_result } }
+  let(:interval_2_result) { { 'anvils' => 100, 'dynamite' => 50 } }
+  let(:filled_2) { { 'timestamp' => timestamp_2, 'event' => filled_2_result } }
+  let(:filled_2_result) { { 'anvils' => 100, 'dynamite' => 50 } }
+
+  describe '#execute' do
+    it 'queries Druid and formats result' do
+      expect(subject.broker).to receive(:query).with(query_opts).and_return(query_result)
+      expect(subject.execute).to eq formatted_results
+    end
+
+    context 'for granularity' do
+      context 'with fill_value' do
+        before do
+          expect(subject.broker).to receive(:query).and_return(query_result)
+        end
+
+        subject { Druid::Query.new(modified_opts) }
+        let(:results) { subject.execute }
+
+        context 'second intervals' do
+          let(:range) { query_time.advance(hours: -2).iso8601 + '/' + query_time.iso8601 }
+          let(:modified_opts) { opts.merge(granularity: 'minute') }
+          let(:intervals) { 2 * 60 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'minute intervals' do
+          let(:modified_opts) { opts.merge(granularity: 'minute') }
+          let(:intervals) { 2 * 24 * 60 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'fifteen minute intervals' do
+          let(:modified_opts) { opts.merge(granularity: 'fifteen_minute') }
+          let(:intervals) { 2 * 24 * 4 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'thirty minute intervals' do
+          let(:modified_opts) { opts.merge(granularity: 'thirty_minute') }
+          let(:intervals) { 2 * 24 * 2 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'hour intervals' do
+          let(:modified_opts) { opts.merge(granularity: 'hour') }
+          let(:intervals) { 2 * 24 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'day intervals' do
+          let(:modified_opts) { opts.merge(granularity: 'day') }
+          let(:intervals) { 2 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'week intervals' do
+          let(:range) { query_time.advance(weeks: -2).iso8601 + '/' + query_time.iso8601 }
+          let(:modified_opts) { opts.merge(granularity: 'week') }
+          let(:intervals) { 2 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'month intervals' do
+          let(:range) { query_time.advance(months: -2).iso8601 + '/' + query_time.iso8601 }
+          let(:modified_opts) { opts.merge(granularity: 'month') }
+          let(:intervals) { 2 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'quarter intervals' do
+          let(:range) { query_time.advance(months: -6).iso8601 + '/' + query_time.iso8601 }
+          let(:modified_opts) { opts.merge(granularity: 'quarter') }
+          let(:intervals) { 2 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+
+        context 'year intervals' do
+          let(:range) { query_time.advance(years: -2).iso8601 + '/' + query_time.iso8601 }
+          let(:modified_opts) { opts.merge(granularity: 'year') }
+          let(:intervals) { 2 + 1 }
+          it { expect(results.size).to eq intervals }
+        end
+      end
+    end
+  end
+
+  describe 'class methods' do
+    subject { Druid::Query }
+    describe '.create' do
+      it 'initializes an object and calls execute' do
+        query = double('query_instance')
+        expect(subject).to receive(:new).with(opts).and_return(query)
+        expect(query).to receive(:execute)
+        subject.create(opts)
+      end
+    end
+  end
+end

--- a/spec/integration/query_spec.rb
+++ b/spec/integration/query_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+WebMock.disable_net_connect!(allow_localhost: true)
+
+describe Druid::Client do
+  before { subject.delete_datasources }
+  after { subject.delete_datasources }
+
+  subject { Druid::Client.new(config) }
+  let(:config) { { tuning_window: 'P7D', strong_delete: true } }
+
+  let(:query_time) { Time.now.utc }
+  let(:query_result) { [ interval_1, interval_2 ] }
+  let(:formatted_results) { [ filled_0, filled_1, filled_2 ] }
+
+  let(:timestamp_0) { query_time.advance(days: -2).beginning_of_day }
+  let(:timestamp_1) { query_time.advance(days: -1).beginning_of_day }
+  let(:timestamp_2) { query_time.beginning_of_day }
+
+  let(:fill_value) { 0 }
+  let(:owner) { "Wile E. Coyote" }
+
+  let(:filled_0) { { 'timestamp' => timestamp_0.iso8601(3), 'event' => filled_0_result } }
+  let(:filled_0_result) { { 'anvils' => fill_value, 'dynamite' => fill_value, 'owner' => owner } }
+
+  let(:datapoint_1) { { timestamp: timestamp_1, dimensions: { 'owner' => owner }, metrics: interval_1_data } }
+  let(:interval_1) { { 'version' => 'v1', 'timestamp' => timestamp_1.iso8601(3), 'event' => interval_1_data.merge('dynamite' => 0, 'owner' => owner) } }
+  let(:interval_1_data) { { 'anvils' => 100 } }
+  let(:filled_1) { { 'version' => 'v1', 'timestamp' => timestamp_1.iso8601(3), 'event' => filled_1_result } }
+  let(:filled_1_result) { { 'anvils' => 100, 'dynamite' => fill_value, 'owner' => owner } }
+
+  let(:datapoint_2) { { timestamp: timestamp_2, dimensions: { 'owner' => owner }, metrics: interval_2_data } }
+  let(:interval_2) { { 'version' => 'v1', 'timestamp' => timestamp_2.iso8601(3), 'event' => interval_2_data.merge('owner' => owner) } }
+  let(:interval_2_data) { { 'anvils' => 100, 'dynamite' => 50 } }
+  let(:filled_2) { { 'version' => 'v1', 'timestamp' => timestamp_2.iso8601(3), 'event' => filled_2_result } }
+  let(:filled_2_result) { { 'anvils' => 100, 'dynamite' => 50, 'owner' => owner } }
+
+  describe '.query' do
+    before do
+      subject.write_point('widgets', datapoint_1)
+      future = subject.write_point('widgets', datapoint_2)
+      wait_for_the_future(future)
+    end
+
+    context 'fill_value' do
+      context 'when not specified' do
+        let(:results) { subject.query(opts) }
+        let(:opts) {
+          {
+            queryType: 'groupBy',
+            dimensions: ['owner'],
+            dataSource: 'widgets',
+            granularity: 'day',
+            intervals: [query_time.advance(days: -2).iso8601 + '/' + query_time.iso8601],
+            aggregations: [
+              { type: 'longSum', name: 'anvils', fieldName: 'anvils' },
+              { type: 'longSum', name: 'dynamite', fieldName: 'dynamite' }
+            ]
+          }
+        }
+
+        it 'does not modify query results' do
+          expect(results).to eq query_result
+        end
+      end
+
+      context 'when specified' do
+        let(:results) { subject.query(opts) }
+        let(:opts) {
+          {
+            queryType: 'groupBy',
+            dimensions: ['owner'],
+            dataSource: 'widgets',
+            granularity: 'day',
+            intervals: [query_time.advance(days: -2).iso8601 + '/' + query_time.iso8601],
+            aggregations: [
+              { type: 'longSum', name: 'anvils', fieldName: 'anvils' },
+              { type: 'longSum', name: 'dynamite', fieldName: 'dynamite' }
+            ],
+            fill_value: fill_value
+          }
+        }
+
+        it 'fills empty aggregations and intervals with value' do
+          expect(results).to eq formatted_results
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/for_query_core.rb
+++ b/spec/support/shared_examples/for_query_core.rb
@@ -2,9 +2,23 @@ require 'support/helpers'
 
 RSpec.shared_examples 'for_query_core' do
   describe '#query' do
-    it 'delegates call' do
-      expect(subject.broker).to receive(:query)
-      subject.query
+    let(:opts) {
+      {
+        queryType: 'timeseries',
+        dataSource: 'widgets',
+        granularity: 'day',
+        intervals: query_time.advance(days: -2).iso8601 + '/' + query_time.iso8601,
+        aggregations: [
+          { type: 'longSum', name: 'anvils', fieldName: 'anvils' },
+          { type: 'longSum', name: 'dynamite', fieldsName: 'dynamite' }
+        ]
+      }
+    }
+    let(:query_time) { Time.now.utc }
+
+    it 'creates query' do
+      expect(Druid::Query).to receive(:create).with(opts.merge(broker: subject.broker))
+      subject.query(opts)
     end
   end
 


### PR DESCRIPTION
This allows a query to specify that empty intervals should be filled
with a value. While Druid does have this ability somewhat baked in, if
an interval has no recorded points, it will not be zero-filled.
