### PR TITLE
feat: logger

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,12 +3,5 @@
 require "bundler/setup"
 require "jruby-druid"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require "irb"
 IRB.start

--- a/lib/druid/client.rb
+++ b/lib/druid/client.rb
@@ -1,5 +1,6 @@
 module Druid
   class Client
+    include Druid::Logging
     include Druid::Queries::Core
     include Druid::Queries::Datasource
     include Druid::Queries::Task
@@ -14,8 +15,15 @@ module Druid
       @config = Druid::Configuration.new(options)
       @broker = Druid::Node::Broker.new(config)
       @coordinator = Druid::Node::Coordinator.new(config)
+      setup_logger
       @overlord = Druid::Node::Overlord.new(config)
       @writer = Druid::Writer::Base.new(config)
+    end
+
+    private
+
+    def setup_logger
+      logger.set_level(config.log_level)
     end
   end
 end

--- a/lib/druid/configuration.rb
+++ b/lib/druid/configuration.rb
@@ -5,6 +5,7 @@ module Druid
     CURATOR_URI = 'localhost:2181'.freeze
     DISCOVERY_PATH = '/druid/discovery'.freeze
     INDEX_SERVICE = 'druid/overlord'.freeze
+    LOG_LEVEL = :warn
     OVERLORD_URI = 'http://localhost:8090/'.freeze
     ROLLUP_GRANULARITY = :minute
     STRONG_DELETE = false # Not recommend to be true for production.
@@ -17,6 +18,7 @@ module Druid
                 :curator_uri,
                 :discovery_path,
                 :index_service,
+                :log_level,
                 :overlord_uri,
                 :rollup_granularity,
                 :strong_delete,
@@ -31,6 +33,7 @@ module Druid
       @curator_uri = opts[:curator_uri] || CURATOR_URI
       @discovery_path = opts[:discovery_path] || DISCOVERY_PATH
       @index_service = opts[:index_service] || INDEX_SERVICE
+      @log_level = opts[:log_level] || LOG_LEVEL
       @overlord_uri = opts[:overlord_uri] || OVERLORD_URI
       @rollup_granularity = rollup_granularity_string(opts[:rollup_granularity])
       @strong_delete = opts[:strong_delete] || STRONG_DELETE

--- a/lib/druid/logger.rb
+++ b/lib/druid/logger.rb
@@ -1,0 +1,82 @@
+# Supported Levels: https://github.com/twitter/util
+require 'logger'
+
+module Druid
+  class Logger
+    include Druid::TopLevelPackages
+
+    attr_accessor :logger
+    delegate :debug, :info, :warn, :error, :fatal, :unknown, to: :logger
+
+    def initialize
+      @logger = ::Logger.new(STDOUT)
+    end
+
+    def set_level(level)
+      set_logger_level(level)
+      set_logback_level(level)
+      set_twitter_level(level)
+    end
+
+    private
+
+    def set_logback_level(level)
+      org.slf4j.LoggerFactory.
+        getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).
+        setLevel(get_logback_level(level))
+    end
+
+    def set_logger_level(level)
+      logger.level = get_logger_level(level)
+    end
+
+    def set_twitter_level(level)
+      com.twitter.logging.Logger.
+        get("com.twitter").
+        setLevel(java.util.logging.Level::WARNING)
+    end
+
+    def get_logback_level(level)
+      ch.qos.logback.classic.Level.const_get(map_logback_level(level))
+    end
+
+    def get_logger_level(level)
+      @logger.class.const_get(map_logger_level(level))
+    end
+
+    def get_twitter_level(level)
+      java.util.logging.Level.const_get(map_twitter_level(level))
+    end
+
+    def map_logback_level(level)
+      case level
+      when :critical
+        'ERROR'.freeze
+      when :fatal
+        'ERROR'.freeze
+      else
+        level.to_s.upcase
+      end
+    end
+
+    def map_logger_level(level)
+      case level
+      when :trace
+        'DEBUG'.freeze
+      when :critical
+        'ERROR'.freeze
+      else
+        level.to_s.upcase
+      end
+    end
+
+    def map_twitter_level(level)
+      case level
+      when :warn
+        'WARNING'.freeze
+      else
+        level.to_s.upcase
+      end
+    end
+  end
+end

--- a/lib/druid/logging.rb
+++ b/lib/druid/logging.rb
@@ -1,1 +1,7 @@
-#TODO: Setup Logging and Do Something Useful
+module Druid
+  module Logging
+    def logger
+      @@logger ||= Druid::Logger.new
+    end
+  end
+end

--- a/lib/druid/top_level_packages.rb
+++ b/lib/druid/top_level_packages.rb
@@ -1,0 +1,11 @@
+module Druid
+  module TopLevelPackages
+    def ch
+      Java::Ch
+    end
+
+    def io
+      Java::Io
+    end
+  end
+end

--- a/lib/druid/writer/tranquilizer.rb
+++ b/lib/druid/writer/tranquilizer.rb
@@ -1,48 +1,16 @@
 module Druid
   module Writer
     module Tranquilizer
-      class << self
-        def ch
-          Java::Ch
-        end
+      extend Druid::TopLevelPackages
 
-        def io
-          Java::Io
-        end
-      end
-      
       java_import com.google.common.collect.ImmutableList
       java_import com.google.common.collect.ImmutableMap
-      java_import ch.qos.logback.classic.Level
-      java_import ch.qos.logback.classic.encoder.PatternLayoutEncoder
-      java_import ch.qos.logback.core.FileAppender
       java_import com.metamx.tranquility.beam.ClusteredBeamTuning
       java_import io.druid.query.aggregation.LongSumAggregatorFactory
       java_import io.druid.granularity.QueryGranularity
       java_import io.druid.data.input.impl.TimestampSpec
       java_import org.apache.curator.framework.CuratorFrameworkFactory
-      java_import org.slf4j.LoggerFactory
-      java_import org.slf4j.Logger
       java_import Java::ScalaCollection::JavaConverters
-
-      logger = Druid::Writer::Tranquilizer::LoggerFactory.getLogger(Druid::Writer::Tranquilizer::Logger.ROOT_LOGGER_NAME)
-      logger.detachAndStopAllAppenders
-
-      appender = Druid::Writer::Tranquilizer::FileAppender.new
-      context = logger.getLoggerContext
-      encoder = Druid::Writer::Tranquilizer::PatternLayoutEncoder.new
-
-      encoder.setPattern("%date %level [%thread] %logger{10} [%file:%line] %msg%n")
-      encoder.setContext(context)
-      encoder.start
-
-      appender.setFile('jruby-druid.log')
-      appender.setEncoder(encoder)
-      appender.setContext(context)
-      appender.start
-
-      logger.addAppender(appender)
-      logger.setLevel(Druid::Writer::Tranquilizer::Level::TRACE)
     end
   end
 end

--- a/lib/druid/writer/tranquilizer/event_listener.rb
+++ b/lib/druid/writer/tranquilizer/event_listener.rb
@@ -2,14 +2,15 @@ module Druid
   module Writer
     module Tranquilizer
       class EventListener
+        include Logging
         include_package com.twitter.util.FutureEventListener
 
         def onSuccess(data)
-          # puts "success: #{data.to_s}" #TODO: Log this (trace)
+          # logger.debug data.to_s
         end
 
         def onFailure(error)
-          puts "failure: #{error.to_s}" #TODO: Log this (debug)
+          logger.warn error.to_s
         end
       end
     end

--- a/lib/jruby-druid.rb
+++ b/lib/jruby-druid.rb
@@ -4,9 +4,12 @@ Dir["#{File.dirname(__FILE__)}/../vendor/tranquility/*.jar"].each { |file| requi
 require "active_support/all"
 require "json"
 
+require "druid/top_level_packages"
 require "druid/configuration"
 require "druid/connection"
 require "druid/errors"
+require "druid/logger"
+require "druid/logging"
 require "druid/query"
 require "druid/version"
 

--- a/spec/druid/client_spec.rb
+++ b/spec/druid/client_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/shared_examples/for_logging'
 require 'support/shared_examples/for_query_core'
 require 'support/shared_examples/for_query_datasource'
 require 'support/shared_examples/for_query_task'
@@ -7,13 +8,24 @@ describe Druid::Client do
   subject { Druid::Client.new(config) }
   let(:config) { {} }
 
-  include_examples 'for_query_core'
-  include_examples 'for_query_datasource'
-  include_examples 'for_query_task'
+  describe 'InstanceMethods' do
+    include_examples 'for_logging'
+    include_examples 'for_query_core'
+    include_examples 'for_query_datasource'
+    include_examples 'for_query_task'
+  end
 
-  describe '.new' do
-    it 'can be initialized with no params' do
-      expect(subject).to be
+  describe 'ClassMethods' do
+    subject { Druid::Client }
+
+    describe '.new' do
+      let(:logger) { Druid::Logger.new }
+
+      it 'initialize and performs setup' do
+        expect_any_instance_of(subject).to receive(:logger).with(no_args).and_return(logger)
+        expect(logger).to receive(:set_level).with(Druid::Configuration::LOG_LEVEL)
+        subject.new(config)
+      end
     end
   end
 end

--- a/spec/druid/configuration_spec.rb
+++ b/spec/druid/configuration_spec.rb
@@ -9,6 +9,7 @@ describe Druid::Configuration do
         expect(subject.curator_uri).to eq Druid::Configuration::CURATOR_URI
         expect(subject.discovery_path).to eq Druid::Configuration::DISCOVERY_PATH
         expect(subject.index_service).to eq Druid::Configuration::INDEX_SERVICE
+        expect(subject.log_level).to eq Druid::Configuration::LOG_LEVEL
         expect(subject.overlord_uri).to eq Druid::Configuration::OVERLORD_URI
         expect(subject.rollup_granularity).to eq Druid::Configuration::ROLLUP_GRANULARITY.to_s.upcase
         expect(subject.strong_delete).to eq Druid::Configuration::STRONG_DELETE
@@ -19,8 +20,9 @@ describe Druid::Configuration do
     end
 
     context 'with params' do
+      let(:object) { Faker::App.name }
       let(:time_duration) { Faker::Number.number(2) }
-      let(:time_window) { Faker::Lorem.characters(4) }
+      let(:char_string) { Faker::Lorem.characters(4) }
       let(:path) { '/druid/path' }
       let(:uri) { Faker::Internet.url }
 
@@ -49,6 +51,11 @@ describe Druid::Configuration do
         it { expect(subject.index_service).to eq path }
       end
 
+      context 'log_level' do
+        subject { Druid::Configuration.new(log_level: char_string)}
+        it { expect(subject.log_level).to eq char_string }
+      end
+
       context 'overlord_uri' do
         subject { Druid::Configuration.new(overlord_uri: uri)}
         it { expect(subject.overlord_uri).to eq uri }
@@ -70,8 +77,8 @@ describe Druid::Configuration do
       end
 
       context 'tuning_window' do
-        subject { Druid::Configuration.new(tuning_window: time_window)}
-        it { expect(subject.tuning_window).to eq time_window }
+        subject { Druid::Configuration.new(tuning_window: char_string)}
+        it { expect(subject.tuning_window).to eq char_string }
       end
 
       context 'wait_time' do

--- a/spec/druid/logger_spec.rb
+++ b/spec/druid/logger_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe Druid::Logger do
+  let(:config) { Druid::Configuration.new(log_level: log_level) }
+  let(:log_level) {}
+
+  describe 'ClassMethods' do
+    subject { Druid::Logger }
+
+    describe '.new' do
+      it 'creates Logger and sets level' do
+        expect(Logger).to receive(:new).with(STDOUT)
+        subject.new
+      end
+    end
+  end
+
+  describe 'InstanceMethods' do
+    subject { Druid::Logger.new }
+    let(:message) { Faker::Lorem.sentence }
+
+    describe '#set_level' do
+      context 'to :foo' do
+        let(:log_level) { :foo }
+        it { expect{ subject.set_level(log_level) }.to raise_error NameError }
+      end
+
+      context 'to :trace' do
+        let(:log_level) { :trace }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+
+      context 'to :debug' do
+        let(:log_level) { :debug }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+
+      context 'to :info' do
+        let(:log_level) { :info }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+
+      context 'to :warn' do
+        let(:log_level) { :warn }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+
+      context 'to :error' do
+        let(:log_level) { :error }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+
+      context 'to :critical' do
+        let(:log_level) { :critical }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+
+      context 'to :fatal' do
+        let(:log_level) { :fatal }
+        it { expect{ subject.set_level(log_level) }.not_to raise_error }
+      end
+    end
+
+    describe '#debug' do
+      it 'delegates to logger' do
+        expect(subject.logger).to receive(:debug).with(message)
+        subject.debug(message)
+      end
+    end
+
+    describe '#info' do
+      it 'delegates to logger' do
+        expect(subject.logger).to receive(:info).with(message)
+        subject.info(message)
+      end
+    end
+
+    describe '#warn' do
+      it 'delegates to logger' do
+        expect(subject.logger).to receive(:warn).with(message)
+        subject.warn(message)
+      end
+    end
+
+    describe '#error' do
+      it 'delegates to logger' do
+        expect(subject.logger).to receive(:error).with(message)
+        subject.error(message)
+      end
+    end
+
+    describe '#fatal' do
+      it 'delegates to logger' do
+        expect(subject.logger).to receive(:fatal).with(message)
+        subject.fatal(message)
+      end
+    end
+
+    describe '#unknown' do
+      it 'delegates to logger' do
+        expect(subject.logger).to receive(:unknown).with(message)
+        subject.unknown(message)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/for_logging.rb
+++ b/spec/support/shared_examples/for_logging.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'for_logging' do
+  describe '#logger' do
+    it 'memoizes an instance of Druid::Logger' do
+      expect(Druid::Logger).to receive(:new).once.and_call_original
+      expect(subject.logger).to be_a Druid::Logger
+      expect(subject.logger).to be_a Druid::Logger
+    end
+  end
+end


### PR DESCRIPTION
Resolves #12 
Create Logger class.
Create Logging module that shares a common logger instance.
Allow log level to be set on Configuration.
Refactor how tranquility log is captured and send to STDOUT.
